### PR TITLE
some small improvements to the frontend

### DIFF
--- a/src/journal_rss/app.py
+++ b/src/journal_rss/app.py
@@ -87,8 +87,8 @@ async def make_feed(
     return templates.TemplateResponse(
         'partials/rss-button.html',
         {
-            'feed-type': 'journals',
-            'feed-id': feed_id,
+            'feed_type': 'journals',
+            'feed_id': feed_id,
             'request': request,
         })
 

--- a/src/journal_rss/models/journal.py
+++ b/src/journal_rss/models/journal.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
 class JournalBase(SQLModel):
     title: str
     publisher: str
+    recent_paper_count: int
     feed: bool = False
     feed_created: Optional[datetime] = None
 
@@ -15,7 +16,6 @@ class Journal(JournalBase, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     issn: List['ISSN'] = Relationship(back_populates='journal')
     papers: List['Paper'] = Relationship(back_populates='journal')
-
 
 class JournalCreate(JournalBase):
     issn: list['ISSNCreate']
@@ -31,10 +31,12 @@ class JournalCreate(JournalBase):
         else:
             issns = res['issn-type']
 
+
         return JournalCreate(
             title=res['title'],
             publisher=res['publisher'],
-            issn = issns
+            issn = issns,
+            recent_paper_count = res['counts']['current-dois']
         )
 
 

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -10,3 +10,11 @@ footer {
     width: 100%;
     text-align: center;
 }
+
+.search-indicator {
+    height: 1em;
+    position: relative;
+    top: -10px;
+    display: inline-block;
+    vertical-align: top;
+}

--- a/src/templates/partials/feed-list.html
+++ b/src/templates/partials/feed-list.html
@@ -4,7 +4,7 @@
     <thead>
     <tr>
       <th>Name</th>
-      <th>ISSN</th>
+      <th>Recent paper count</th>
       <th>Publisher</th>
       <th>Feed</th>
     </tr>
@@ -13,11 +13,7 @@
     {% for journal in journals %}
     <tr>
         <td><a href="/journals/{{ journal.issn[0].value }}">{{ journal.title }}</a></td>
-        <td>
-            {% for issn in journal.issn %}
-            {{ issn.value }},
-            {% endfor %}
-        </td>
+        <td>{{ journal.recent_paper_count }}</td>
         <td>
             {{ journal.publisher }}
         </td>


### PR DESCRIPTION
the commits summarize the changes:
 - fix a bug where clicking "+" would not provide the correct url for rss button
 - add some css to force the search indicator to fit on the same line, to make the table rows more compact
 - switch ISSN to recent paper count in table

The last one is somewhat opinionated. I don't find the ISSN useful when checking the journal, but the recent paper count available on crossref instantly tells me if the feed is up to date. 
I wonder if we should just remove feeds with 0 recent papers, or get the latest papers from somewhere else since crossref is clearly not up to date??

