### PR TITLE
Bugfix: Filter non-paper types

### DIFF
--- a/src/journal_rss/models/paper.py
+++ b/src/journal_rss/models/paper.py
@@ -162,6 +162,10 @@ def _simplify_datetime(date: dict) -> Optional[datetime]:
         if isinstance(parts[0], list):
             parts = parts[0]
 
+        if parts[0] is None:
+            # eg. "issued" on http://api.crossref.org/journals/1674-9251/works?rows=1&offset=566&sort=published&order=desc
+            return None
+
         if len(parts) == 1:
             # add the first month of the year
             parts.append(1)

--- a/src/journal_rss/models/paper.py
+++ b/src/journal_rss/models/paper.py
@@ -1,14 +1,13 @@
-import sys
-import typing
 from typing import Optional, Union, Tuple, List, Dict, Literal, TYPE_CHECKING
+from datetime import datetime
+
+from sqlmodel import SQLModel, Field, Relationship
 if TYPE_CHECKING:
     from journal_rss.models import Journal
 
 from journal_rss.const import SCIHUB_URL
 
 
-from datetime import datetime, date
-from sqlmodel import SQLModel, Field, Relationship
 
 class PaperBase(SQLModel):
     """https://api.crossref.org/swagger-ui/index.html#model-Work"""

--- a/src/journal_rss/models/paper.py
+++ b/src/journal_rss/models/paper.py
@@ -1,5 +1,5 @@
 from typing import Optional, Union, Tuple, List, Dict, Literal, TYPE_CHECKING
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlmodel import SQLModel, Field, Relationship
 if TYPE_CHECKING:
@@ -154,7 +154,7 @@ def _simplify_datetime(date: dict) -> Optional[datetime]:
         timestamp = float(date.get('timestamp'))
         if timestamp > 1_000_000_000_000:
             timestamp = timestamp / 1000
-        return datetime.fromtimestamp(timestamp)
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc)
     elif date.get('date-time', None):
         return datetime.fromisoformat(date.get('date-time'))
     elif date.get('date-parts', None):
@@ -173,7 +173,7 @@ def _simplify_datetime(date: dict) -> Optional[datetime]:
         if len(parts) == 2:
             # add the first day of the month
             parts.append(1)
-        return datetime(*parts)
+        return datetime(*parts, tzinfo=timezone.utc)
     else:
         raise ValueError(f"Cant handle date: {date}")
 

--- a/src/journal_rss/services/crossref.py
+++ b/src/journal_rss/services/crossref.py
@@ -15,6 +15,17 @@ from journal_rss import init_logger
 
 CROSSREF_API_URL = 'https://api.crossref.org/'
 USER_AGENT = 'journal-rss (https://github.com/sneakers-the-rat/journal-rss)'
+PAPER_TYPES = (
+    'journal-article', 'book', 'book-chapter', 'book-part', 'book-section',
+    'edited-book', 'proceedings-article', 'reference-book', 'dissertation',
+    'report'
+)
+"""
+Crossref types that we'll treat as a "paper"
+
+See http://api.crossref.org/types
+"""
+
 
 def crossref_get(
         endpoint: str,
@@ -100,14 +111,16 @@ def fetch_paper_page(
         issn:str,
         rows: int = 100,
         offset: int = 0,
-        since_date: Optional[datetime] = None
+        since_date: Optional[datetime] = None,
+        **kwargs
     ) -> list[PaperCreate]:
     # TODO: Select only fields in the model
     params = {
         'sort': 'published',
         'order': 'desc',
         'rows': rows,
-        'offset': offset
+        'offset': offset,
+        **kwargs
     }
     if since_date:
         params['from-pub-date'] = since_date.strftime('%y-%m-%d')
@@ -189,5 +202,3 @@ def populate_papers(issn: str, limit: int = 1000, rows=100):
             break
 
     logger.debug('completed paper fetch for %s', issn)
-
-

--- a/src/journal_rss/services/crossref.py
+++ b/src/journal_rss/services/crossref.py
@@ -133,7 +133,7 @@ def fetch_paper_page(
 
 def _clean_paper_page(res: dict) -> list[PaperCreate]:
     """Making a separate function in case we need to do some filtering here"""
-    return [PaperCreate.from_crossref(item) for item in res['message']['items']]
+    return [PaperCreate.from_crossref(item) for item in res['message']['items'] if item.get('type', None) in PAPER_TYPES]
 
 def store_papers(papers: list[PaperCreate], issn: str) -> list[Paper]:
     engine = get_engine()

--- a/tests/test_crossref.py
+++ b/tests/test_crossref.py
@@ -50,6 +50,11 @@ def test_fetch_paper_page(issn, kwargs):
     # the models validating is the test passing lol
     papers = fetch_paper_page(issn, **kwargs)
 
+def test_filter_non_papers():
+    # result known to be a `journal` type
+    journal_item = fetch_paper_page('1674-9251', rows=1, filter='type:journal')
+    assert len(journal_item) == 0
+
 
 @pytest.mark.parametrize(
     ('issn'),

--- a/tests/test_crossref.py
+++ b/tests/test_crossref.py
@@ -36,21 +36,20 @@ def test_search_journal(query, issn, memory_db):
 
 
 @pytest.mark.parametrize(
-    ('issn,kwargs'),
+    ('issn'),
     (
-        ['0896-6273', {}],  # Neuron
-        ['1674-9251', {'rows':1, 'filter': 'type:journal'}]   # Journal that returns itself as a work - https://github.com/sneakers-the-rat/journal-rss/issues/16
+        '0896-6273',  # Neuron
     )
 )
-def test_fetch_paper_page(issn, kwargs):
+def test_fetch_paper_page(issn):
+    # the models validating is the test passing lol
+    papers = fetch_paper_page(issn)
+
+def test_filter_non_papers():
     """
     Tests issues:
     - https://github.com/sneakers-the-rat/journal-rss/issues/16
     """
-    # the models validating is the test passing lol
-    papers = fetch_paper_page(issn, **kwargs)
-
-def test_filter_non_papers():
     # result known to be a `journal` type
     journal_item = fetch_paper_page('1674-9251', rows=1, filter='type:journal')
     assert len(journal_item) == 0

--- a/tests/test_crossref.py
+++ b/tests/test_crossref.py
@@ -36,14 +36,19 @@ def test_search_journal(query, issn, memory_db):
 
 
 @pytest.mark.parametrize(
-    ('issn'),
+    ('issn,kwargs'),
     (
-        '0896-6273',  # Neuron
+        ['0896-6273', {}],  # Neuron
+        ['1674-9251', {'rows':1, 'offset': 566, 'sort': 'published'}]   # Journal that returns itself as a work - https://github.com/sneakers-the-rat/journal-rss/issues/16
     )
 )
-def test_fetch_paper_page(issn):
+def test_fetch_paper_page(issn, kwargs):
+    """
+    Tests issues:
+    - https://github.com/sneakers-the-rat/journal-rss/issues/16
+    """
     # the models validating is the test passing lol
-    papers = fetch_paper_page(issn)
+    papers = fetch_paper_page(issn, **kwargs)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_crossref.py
+++ b/tests/test_crossref.py
@@ -39,7 +39,7 @@ def test_search_journal(query, issn, memory_db):
     ('issn,kwargs'),
     (
         ['0896-6273', {}],  # Neuron
-        ['1674-9251', {'rows':1, 'offset': 566, 'sort': 'published'}]   # Journal that returns itself as a work - https://github.com/sneakers-the-rat/journal-rss/issues/16
+        ['1674-9251', {'rows':1, 'filter': 'type:journal'}]   # Journal that returns itself as a work - https://github.com/sneakers-the-rat/journal-rss/issues/16
     )
 )
 def test_fetch_paper_page(issn, kwargs):

--- a/tests/test_paper.py
+++ b/tests/test_paper.py
@@ -1,0 +1,27 @@
+import pytest
+from datetime import datetime, timezone
+
+from journal_rss.models.paper import _simplify_datetime
+
+@pytest.mark.parametrize(
+    'test,expected',
+    [
+        # humongous unix timestamps
+        ({'timestamp':1704356642147.0488}, datetime(2024, 1, 4, 0, 24, 2, 147049)),
+        # regular unix timestamp
+        ({'timestamp':1704356730.163272}, datetime(2024, 1, 4, 0, 25, 30, 163272)),
+        # timestamp as string
+        ({'timestamp':'1704356730.163272'}, datetime(2024, 1, 4, 0, 25, 30, 163272)),
+        # isoformat timestamp
+        ({'date-time': '2024-01-04T00:28:22Z'}, datetime(2024, 1, 4, 0, 28, 22, tzinfo=timezone.utc)),
+        # regular date parts
+        ({'date-parts': [[2024,1,1]]}, datetime(2024,1,1)),
+        # truncated date parts
+        ({'date-parts': [[2024,1]]}, datetime(2024,1,1)),
+        ({'date-parts': [[2024]]}, datetime(2024,1,1)),
+        # https://github.com/sneakers-the-rat/journal-rss/issues/16
+        ({'date-parts': [[None]]}, None)
+    ]
+)
+def test_simplify_datetime(test, expected):
+    assert _simplify_datetime(test) == expected

--- a/tests/test_paper.py
+++ b/tests/test_paper.py
@@ -7,18 +7,18 @@ from journal_rss.models.paper import _simplify_datetime
     'test,expected',
     [
         # humongous unix timestamps
-        ({'timestamp':1704356642147.0488}, datetime(2024, 1, 4, 8, 24, 2, 147049)),
+        ({'timestamp':1704356642147.0488}, datetime(2024, 1, 4, 8, 24, 2, 147049, tzinfo=timezone.utc)),
         # regular unix timestamp
-        ({'timestamp':1704356730.163272}, datetime(2024, 1, 4, 8, 25, 30, 163272)),
+        ({'timestamp':1704356730.163272}, datetime(2024, 1, 4, 8, 25, 30, 163272, tzinfo=timezone.utc)),
         # timestamp as string
-        ({'timestamp':'1704356730.163272'}, datetime(2024, 1, 4, 8, 25, 30, 163272)),
+        ({'timestamp':'1704356730.163272'}, datetime(2024, 1, 4, 8, 25, 30, 163272, tzinfo=timezone.utc)),
         # isoformat timestamp
         ({'date-time': '2024-01-04T00:28:22Z'}, datetime(2024, 1, 4, 0, 28, 22, tzinfo=timezone.utc)),
         # regular date parts
-        ({'date-parts': [[2024,1,1]]}, datetime(2024,1,1)),
+        ({'date-parts': [[2024,1,1]]}, datetime(2024,1,1, tzinfo=timezone.utc)),
         # truncated date parts
-        ({'date-parts': [[2024,1]]}, datetime(2024,1,1)),
-        ({'date-parts': [[2024]]}, datetime(2024,1,1)),
+        ({'date-parts': [[2024,1]]}, datetime(2024,1,1, tzinfo=timezone.utc)),
+        ({'date-parts': [[2024]]}, datetime(2024,1,1, tzinfo=timezone.utc)),
         # https://github.com/sneakers-the-rat/journal-rss/issues/16
         ({'date-parts': [[None]]}, None)
     ]

--- a/tests/test_paper.py
+++ b/tests/test_paper.py
@@ -7,11 +7,11 @@ from journal_rss.models.paper import _simplify_datetime
     'test,expected',
     [
         # humongous unix timestamps
-        ({'timestamp':1704356642147.0488}, datetime(2024, 1, 4, 0, 24, 2, 147049)),
+        ({'timestamp':1704356642147.0488}, datetime(2024, 1, 4, 8, 24, 2, 147049)),
         # regular unix timestamp
-        ({'timestamp':1704356730.163272}, datetime(2024, 1, 4, 0, 25, 30, 163272)),
+        ({'timestamp':1704356730.163272}, datetime(2024, 1, 4, 8, 25, 30, 163272)),
         # timestamp as string
-        ({'timestamp':'1704356730.163272'}, datetime(2024, 1, 4, 0, 25, 30, 163272)),
+        ({'timestamp':'1704356730.163272'}, datetime(2024, 1, 4, 8, 25, 30, 163272)),
         # isoformat timestamp
         ({'date-time': '2024-01-04T00:28:22Z'}, datetime(2024, 1, 4, 0, 28, 22, tzinfo=timezone.utc)),
         # regular date parts


### PR DESCRIPTION
Fix: https://github.com/sneakers-the-rat/journal-rss/issues/16

16 was actually two bugs in a trenchcoat. First the simplify datetime function wasn't handling a null-like value (specifically, `{'date-parts': [[None]]}`), and then it choked on how the journal didn't have a `'published'` field. I imagine we'll need to keep doing a bunch of massaging to handle incomplete metadata. I am a little hesitant to just mark all timestamp columns as "optional" because we do need _one_ of them, but ideally we'll make a routine to get one of those and store them in a required `timestamp` column.

Anyway
- two commits with correctly failing tests to catch both of those
- add a tuple of types that we'll consider "papers" 
- filter things that aren't in that tuple when we clean results pages, currently i'm doing this silently but we could also log that if we want. the query is specifically for paper-like things, so dropping those should be expected.
- add tests for these errors.

i'll leave this open until tmrw if people have feelings about this and then merge :)